### PR TITLE
Fixed Readme.md grammer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Code for the La Salle Robotics Team 5181's 2016 Season Robot "Sigmund" participa
 ##Code License
 ![GNU GPL](https://www.gnu.org/graphics/gplv3-127x51.png)
 
-The entire `2016Robot` repository and all its affiliated codes are released under The GNU General Public License v3. A more detailed version of this license can be accessed in the `LICENSE` file located in the same repository. The official version of The GNU GPLv3 can be accessed at [the FSF website](https://www.gnu.org/licenses/gpl-3.0.en.html).
+The entire `2016Robot` repository and all of its affiliated codes are released under The GNU General Public License v3. A more detailed version of this license can be accessed in the `LICENSE` file located in the same repository. The official version of The GNU GPLv3 can be accessed at [the FSF website](https://www.gnu.org/licenses/gpl-3.0.en.html).
 
 ##The authors
 


### PR DESCRIPTION
Adding `all` to Readme.md sounds better despite it having no grammatical importance.